### PR TITLE
Replaced resetTransform with setTransform

### DIFF
--- a/src/Engine/Renderer/render.js
+++ b/src/Engine/Renderer/render.js
@@ -309,7 +309,7 @@ export function renderEntity(entity, x, y, width, height, eWidth, eHeight) {
     this.context.globalCompositeOperation = "source-over";
   }
 
-  this.context.resetTransform();
+  this.context.setTransform(1, 0, 0, 1, 0, 0);
 
   return void 0;
 


### PR DESCRIPTION
Replaced CanvasRenderingContext2D#resetTransform with CanvasRenderingContext2D#setTransform due to poor cross-browser compatibility for the former. See https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/resetTransform for more details.
