### PR TITLE
Fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "scripts": {
     "watch": "webpack --watch"
   },
-  "dependencies": {
-    "json-stringify-safe": "^5.0.1"
-  },
   "devDependencies": {
     "babel-core": "^6.0.20",
     "babel-loader": "^6.0.1",
@@ -17,6 +14,7 @@
     "webpack": "^1.12.2"
   },
   "dependencies": {
-    "babel-runtime": "^6.3.19"
+    "babel-runtime": "^6.3.19",
+    "json-stringify-safe": "^5.0.1"
   }
 }


### PR DESCRIPTION
json-stringify-safe isn't installed because of two dependencies one overriding the other. Making compileing impossible because of missing dependency.
